### PR TITLE
Add support for a path component in the registry url

### DIFF
--- a/lib/avro_turf/confluent_schema_registry.rb
+++ b/lib/avro_turf/confluent_schema_registry.rb
@@ -14,6 +14,7 @@ class AvroTurf::ConfluentSchemaRegistry
     client_key_data: nil
   )
     @logger = logger
+    @base_path = URI.parse(url).path.chomp('/')
     headers = {
       "Content-Type" => CONTENT_TYPE
     }
@@ -119,7 +120,15 @@ class AvroTurf::ConfluentSchemaRegistry
 
   def request(path, **options)
     options = { expects: 200 }.merge!(options)
-    response = @connection.request(path: path, **options)
+    response = @connection.request(path: path_with_prefix(path), **options)
     JSON.parse(response.body)
+  end
+
+  ##
+  # Get the final path to request from the registry server
+  def path_with_prefix(path)
+    return path if @base_path == ''
+
+    "#{@base_path}#{path}"
   end
 end

--- a/lib/avro_turf/test/fake_prefixed_confluent_schema_registry_server.rb
+++ b/lib/avro_turf/test/fake_prefixed_confluent_schema_registry_server.rb
@@ -1,0 +1,142 @@
+require 'sinatra/base'
+
+class FakePrefixedConfluentSchemaRegistryServer < Sinatra::Base
+  SUBJECTS = Hash.new { Array.new }
+  SCHEMAS = []
+  CONFIGS = Hash.new
+  SUBJECT_NOT_FOUND = { error_code: 40401, message: 'Subject not found' }.to_json.freeze
+  VERSION_NOT_FOUND = { error_code: 40402, message: 'Version not found' }.to_json.freeze
+  SCHEMA_NOT_FOUND = { error_code: 40403, message: 'Schema not found' }.to_json.freeze
+  DEFAULT_GLOBAL_CONFIG = { 'compatibility' => 'BACKWARD'.freeze }.freeze
+  BASE_PATH = '/some-prefix'.freeze
+
+  @global_config = DEFAULT_GLOBAL_CONFIG.dup
+
+  class << self
+    attr_reader :global_config
+  end
+
+  helpers do
+    def parse_schema
+      request.body.rewind
+      JSON.parse(request.body.read).fetch("schema").tap do |schema|
+        Avro::Schema.parse(schema)
+      end
+    end
+
+    def parse_config
+      request.body.rewind
+      JSON.parse(request.body.read)
+    end
+
+    def global_config
+      self.class.global_config
+    end
+  end
+
+  post "#{BASE_PATH}/subjects/:subject/versions" do
+    schema = parse_schema
+    ids_for_subject = SUBJECTS[params[:subject]]
+
+    schemas_for_subject =
+      SCHEMAS.select
+             .with_index { |_, i| ids_for_subject.include?(i) }
+
+    if schemas_for_subject.include?(schema)
+      schema_id = SCHEMAS.index(schema)
+    else
+      SCHEMAS << schema
+      schema_id = SCHEMAS.size - 1
+      SUBJECTS[params[:subject]] = SUBJECTS[params[:subject]] << schema_id
+    end
+
+    { id: schema_id }.to_json
+  end
+
+  get "#{BASE_PATH}/schemas/ids/:schema_id" do
+    schema = SCHEMAS.at(params[:schema_id].to_i)
+    halt(404, SCHEMA_NOT_FOUND) unless schema
+    { schema: schema }.to_json
+  end
+
+  get "#{BASE_PATH}/subjects" do
+    SUBJECTS.keys.to_json
+  end
+
+  get "#{BASE_PATH}/subjects/:subject/versions" do
+    schema_ids = SUBJECTS[params[:subject]]
+    halt(404, SUBJECT_NOT_FOUND) if schema_ids.empty?
+    (1..schema_ids.size).to_a.to_json
+  end
+
+  get "#{BASE_PATH}/subjects/:subject/versions/:version" do
+    schema_ids = SUBJECTS[params[:subject]]
+    halt(404, SUBJECT_NOT_FOUND) if schema_ids.empty?
+
+    schema_id = if params[:version] == 'latest'
+                  schema_ids.last
+                else
+                  schema_ids.at(Integer(params[:version]) - 1)
+                end
+    halt(404, VERSION_NOT_FOUND) unless schema_id
+
+    schema = SCHEMAS.at(schema_id)
+
+    {
+      name: params[:subject],
+      version: schema_ids.index(schema_id) + 1,
+      id: schema_id,
+      schema: schema
+    }.to_json
+  end
+
+  post "#{BASE_PATH}/subjects/:subject" do
+    schema = parse_schema
+
+    # Note: this does not actually handle the same schema registered under
+    # multiple subjects
+    schema_id = SCHEMAS.index(schema)
+
+    halt(404, SCHEMA_NOT_FOUND) unless schema_id
+
+    {
+      subject: params[:subject],
+      id: schema_id,
+      version: SUBJECTS[params[:subject]].index(schema_id) + 1,
+      schema: schema
+    }.to_json
+  end
+
+  post "#{BASE_PATH}/compatibility/subjects/:subject/versions/:version" do
+    # The ruby avro gem does not yet include a compatibility check between schemas.
+    # See https://github.com/apache/avro/pull/170
+    raise NotImplementedError
+  end
+
+  get "#{BASE_PATH}/config" do
+    global_config.to_json
+  end
+
+  put "#{BASE_PATH}/config" do
+    global_config.merge!(parse_config).to_json
+  end
+
+  get "#{BASE_PATH}/config/:subject" do
+    CONFIGS.fetch(params[:subject], global_config).to_json
+  end
+
+  put "#{BASE_PATH}/config/:subject" do
+    config = parse_config
+    subject = params[:subject]
+    CONFIGS.fetch(subject) do
+      CONFIGS[subject] = {}
+    end.merge!(config).to_json
+  end
+
+  def self.clear
+    SUBJECTS.clear
+    SCHEMAS.clear
+    CONFIGS.clear
+    @global_config = DEFAULT_GLOBAL_CONFIG.dup
+  end
+end

--- a/spec/confluent_schema_registry_spec.rb
+++ b/spec/confluent_schema_registry_spec.rb
@@ -1,6 +1,7 @@
 require 'webmock/rspec'
 require 'avro_turf/confluent_schema_registry'
 require 'avro_turf/test/fake_confluent_schema_registry_server'
+require 'avro_turf/test/fake_prefixed_confluent_schema_registry_server'
 
 describe AvroTurf::ConfluentSchemaRegistry do
   let(:client_cert) { "test client cert" }
@@ -8,6 +9,20 @@ describe AvroTurf::ConfluentSchemaRegistry do
   let(:client_key_pass) { "test client key password" }
 
   it_behaves_like "a confluent schema registry client" do
+    let(:registry) {
+      described_class.new(
+        registry_url,
+        logger: logger,
+        client_cert: client_cert,
+        client_key: client_key,
+        client_key_pass: client_key_pass
+      )
+    }
+  end
+
+  it_behaves_like "a confluent schema registry client" do
+    let(:registry_url) { 'http://registry.example.com/some-prefix' }
+    let(:fake_server_class) { FakePrefixedConfluentSchemaRegistryServer }
     let(:registry) {
       described_class.new(
         registry_url,

--- a/spec/support/confluent_schema_registry_context.rb
+++ b/spec/support/confluent_schema_registry_context.rb
@@ -4,6 +4,7 @@ shared_examples_for "a confluent schema registry client" do
   let(:logger) { Logger.new(StringIO.new) }
   let(:registry_url) { "http://registry.example.com" }
   let(:subject_name) { "some-subject" }
+  let(:fake_server_class) { FakeConfluentSchemaRegistryServer }
   let(:schema) do
     {
       type: "record",
@@ -15,8 +16,8 @@ shared_examples_for "a confluent schema registry client" do
   end
 
   before do
-    stub_request(:any, /^#{registry_url}/).to_rack(FakeConfluentSchemaRegistryServer)
-    FakeConfluentSchemaRegistryServer.clear
+    stub_request(:any, /^#{registry_url}/).to_rack(fake_server_class)
+    fake_server_class.clear
   end
 
   describe "#register and #fetch" do

--- a/spec/test/fake_prefixed_confluent_schema_registry_server_spec.rb
+++ b/spec/test/fake_prefixed_confluent_schema_registry_server_spec.rb
@@ -1,0 +1,40 @@
+require 'rack/test'
+require 'avro_turf/test/fake_prefixed_confluent_schema_registry_server'
+
+describe FakePrefixedConfluentSchemaRegistryServer do
+  include Rack::Test::Methods
+
+  def app; described_class; end
+
+  let(:schema) do
+    {
+      type: "record",
+      name: "person",
+      fields: [
+        { name: "name", type: "string" }
+      ]
+    }.to_json
+  end
+
+  describe 'POST /some-prefix/subjects/:subject/versions' do
+    it 'returns the same schema ID when invoked with same schema and same subject' do
+      post '/some-prefix/subjects/person/versions', { schema: schema }.to_json, 'CONTENT_TYPE' => 'application/vnd.schemaregistry+json'
+
+      expected_id = JSON.parse(last_response.body).fetch('id')
+
+      post '/some-prefix/subjects/person/versions', { schema: schema }.to_json, 'CONTENT_TYPE' => 'application/vnd.schemaregistry+json'
+
+      expect(JSON.parse(last_response.body).fetch('id')).to eq expected_id
+    end
+
+    it 'returns a different schema ID when invoked with same schema and different subject' do
+      post '/some-prefix/subjects/person/versions', { schema: schema }.to_json, 'CONTENT_TYPE' => 'application/vnd.schemaregistry+json'
+
+      original_id = JSON.parse(last_response.body).fetch('id')
+
+      post '/some-prefix/subjects/happy-person/versions', { schema: schema }.to_json, 'CONTENT_TYPE' => 'application/vnd.schemaregistry+json'
+
+      expect(JSON.parse(last_response.body).fetch('id')).not_to eq original_id
+    end
+  end
+end


### PR DESCRIPTION
This solution works, but isn't the greatest. The fake server should be DRYed up and its specs maybe completed. There is a bug in the current ConfluentSchemaRegistry if a proxy is provided and ActiveSupport is not loaded. 